### PR TITLE
feat: gateway userId 추출 필터 추가

### DIFF
--- a/apigateway-service/src/main/java/com/khi/apigatewayservice/common/filter/JwtAuthenticationFilter.java
+++ b/apigateway-service/src/main/java/com/khi/apigatewayservice/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,127 @@
+package com.khi.apigatewayservice.common.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.khi.apigatewayservice.common.api.ApiResponse;
+import com.khi.apigatewayservice.common.util.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)  // 로깅 필터 다음에 실행
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements WebFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+
+    private static final String[] PUBLIC_PATHS = {
+            "/api/auth/login",
+            "/api/auth/signup",
+            "/actuator/health",
+            "/swagger-ui",
+            "/v3/api-docs",
+            "/security/jwt/reissue",
+            "/swagger-ui/index.html",
+            "/swagger-ui/swagger-ui.css",
+            "/swagger-ui/index.css",
+            "/swagger-ui/swagger-ui-bundle.js",
+            "/swagger-ui/swagger-ui-standalone-preset.js",
+            "/swagger-ui/swagger-initializer.js",
+            "/v3/api-docs/swagger-config",
+            "/security/test"
+    };
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+
+        ServerHttpRequest request = exchange.getRequest();
+        String path = request.getURI().getPath();
+
+        if (isPublicPath(path)) {
+            log.info("[PUBLIC PATH] {}", path);
+            return chain.filter(exchange);
+        }
+
+        String token = extractToken(request);
+
+        if (token == null) {
+            log.error("[NO TOKEN] {}", path);
+            return onError(exchange, "토큰이 없습니다.", HttpStatus.UNAUTHORIZED);
+        }
+
+        try {
+            String userId = jwtTokenProvider.getUserIdFromToken(token);
+            log.info("[JWT VALID] userId: {}, path: {}", userId, path);
+
+            ServerHttpRequest modifiedRequest = request.mutate()
+                    .header("X-User-Id", userId)
+                    .build();
+
+            ServerWebExchange modifiedExchange = exchange.mutate()
+                    .request(modifiedRequest)
+                    .build();
+
+            return chain.filter(modifiedExchange);
+
+        } catch (Exception e) {
+            log.error("[JWT INVALID] {}", e.getMessage());
+            return onError(exchange, "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    private boolean isPublicPath(String path) {
+        for (String publicPath : PUBLIC_PATHS) {
+            if (path.startsWith(publicPath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String extractToken(ServerHttpRequest request) {
+        String bearerToken = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+
+    private Mono<Void> onError(ServerWebExchange exchange, String message, HttpStatus status) {
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(status);
+        response.getHeaders().add(HttpHeaders.CONTENT_TYPE, "application/json");
+
+        try {
+            ApiResponse<?> apiResponse = ApiResponse.error(message);
+            String errorJson = objectMapper.writeValueAsString(apiResponse);
+
+            return response.writeWith(
+                    Mono.just(response.bufferFactory().wrap(errorJson.getBytes()))
+            );
+        } catch (JsonProcessingException e) {
+            log.error("[JSON PROCESSING ERROR] {}", e.getMessage());
+            String fallbackJson = String.format(
+                    "{\"status\":\"error\",\"message\":\"%s\",\"data\":null}",
+                    message
+            );
+            return response.writeWith(
+                    Mono.just(response.bufferFactory().wrap(fallbackJson.getBytes()))
+            );
+        }
+    }
+}

--- a/apigateway-service/src/main/java/com/khi/apigatewayservice/common/util/JwtTokenProvider.java
+++ b/apigateway-service/src/main/java/com/khi/apigatewayservice/common/util/JwtTokenProvider.java
@@ -1,0 +1,46 @@
+package com.khi.apigatewayservice.common.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        log.info(claims.toString());
+
+        return claims.getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
게이트웨이에 jwt 검증 및 유저 id를 추출해 헤더에 추가하는 필터를 추가하였습니다.
추후 각 모듈 컨트롤러에서 헤더를 꺼내 사용하면 됩니다.